### PR TITLE
Add minimal views for each step in the record a mammogram journey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ help: # Print help @Others
 test: test-unit test-lint # Run all tests @Testing
 
 test-unit: # Run unit tests @Testing
-	DEBUG=1 poetry run pytest
+	TESTING=1 poetry run pytest
 
 test-lint: # Lint files @Testing
 	# TODO

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ help: # Print help @Others
 test: test-unit test-lint # Run all tests @Testing
 
 test-unit: # Run unit tests @Testing
-	DEBUG=1 TESTING=1 poetry run pytest
+	poetry run pytest
 
 test-lint: # Lint files @Testing
 	# TODO

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ help: # Print help @Others
 test: test-unit test-lint # Run all tests @Testing
 
 test-unit: # Run unit tests @Testing
-	TESTING=1 poetry run pytest
+	DEBUG=1 TESTING=1 poetry run pytest
 
 test-lint: # Lint files @Testing
 	# TODO

--- a/manage_breast_screening/clinics/tests/test_models.py
+++ b/manage_breast_screening/clinics/tests/test_models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from datetime import timezone as tz
 
 import pytest
 import time_machine
@@ -15,11 +16,11 @@ def test_clinic_is_scheduled():
 
 
 @pytest.mark.django_db
-@time_machine.travel(datetime(2025, 1, 1, 10))
+@time_machine.travel(datetime(2025, 1, 1, 10, tzinfo=tz.utc))
 def test_status_filtering():
-    current = ClinicFactory.create(starts_at=datetime(2025, 1, 1, 9))
-    future = ClinicFactory.create(starts_at=datetime(2025, 1, 2, 9))
-    past = ClinicFactory.create(starts_at=datetime(2024, 1, 1, 9))
+    current = ClinicFactory.create(starts_at=datetime(2025, 1, 1, 9, tzinfo=tz.utc))
+    future = ClinicFactory.create(starts_at=datetime(2025, 1, 2, 9, tzinfo=tz.utc))
+    past = ClinicFactory.create(starts_at=datetime(2024, 1, 1, 9, tzinfo=tz.utc))
 
     assertQuerySetEqual(
         models.Clinic.objects.all(), {current, future, past}, ordered=False

--- a/manage_breast_screening/config/settings.py
+++ b/manage_breast_screening/config/settings.py
@@ -37,6 +37,7 @@ SECRET_KEY = environ.get("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = boolean_env("DEBUG", default=False)
+TESTING = boolean_env("TESTING", default=False)
 
 allowed_hosts = environ.get("ALLOWED_HOSTS")
 ALLOWED_HOSTS = allowed_hosts.split(",") if allowed_hosts else []
@@ -114,7 +115,11 @@ DATABASES = {
 
 STORAGES = {
     "staticfiles": {
-        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        "BACKEND": (
+            "django.contrib.staticfiles.storage.StaticFilesStorage"
+            if TESTING
+            else "whitenoise.storage.CompressedManifestStaticFilesStorage"
+        ),
     },
 }
 

--- a/manage_breast_screening/config/settings.py
+++ b/manage_breast_screening/config/settings.py
@@ -37,7 +37,6 @@ SECRET_KEY = environ.get("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = boolean_env("DEBUG", default=False)
-TESTING = boolean_env("TESTING", default=False)
 
 allowed_hosts = environ.get("ALLOWED_HOSTS")
 ALLOWED_HOSTS = allowed_hosts.split(",") if allowed_hosts else []
@@ -115,11 +114,7 @@ DATABASES = {
 
 STORAGES = {
     "staticfiles": {
-        "BACKEND": (
-            "django.contrib.staticfiles.storage.StaticFilesStorage"
-            if TESTING
-            else "whitenoise.storage.CompressedManifestStaticFilesStorage"
-        ),
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
     },
 }
 

--- a/manage_breast_screening/config/settings_test.py
+++ b/manage_breast_screening/config/settings_test.py
@@ -1,0 +1,13 @@
+from .settings import *
+
+SECRET_KEY = "testing"
+
+STORAGES = {
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
+MIDDLEWARE.remove(
+    "whitenoise.middleware.WhiteNoiseMiddleware",
+)

--- a/manage_breast_screening/config/urls.py
+++ b/manage_breast_screening/config/urls.py
@@ -26,5 +26,12 @@ urlpatterns = [
     path(
         "clinics/", include("manage_breast_screening.clinics.urls", namespace="clinics")
     ),
+    path(
+        "record-a-mammogram/",
+        include(
+            "manage_breast_screening.record_a_mammogram.urls",
+            namespace="record_a_mammogram",
+        ),
+    ),
     path("", RedirectView.as_view(pattern_name="clinics:index")),
 ]

--- a/manage_breast_screening/record_a_mammogram/admin.py
+++ b/manage_breast_screening/record_a_mammogram/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/manage_breast_screening/record_a_mammogram/apps.py
+++ b/manage_breast_screening/record_a_mammogram/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class RecordAMammogramConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'record_a_mammogram'

--- a/manage_breast_screening/record_a_mammogram/forms.py
+++ b/manage_breast_screening/record_a_mammogram/forms.py
@@ -1,0 +1,47 @@
+from django import forms
+
+
+class ScreeningAppointmentForm(forms.Form):
+    decision = forms.ChoiceField(
+        choices=(
+            ("continue", "Yes, go to medical information"),
+            ("dropout", "No, screening cannot proceed"),
+        ),
+        required=True,
+        widget=forms.RadioSelect(),
+    )
+
+    def save(self):
+        pass
+
+
+class AskForMedicalInformationForm(forms.Form):
+    decision = forms.ChoiceField(
+        choices=(
+            ("continue", "Yes, mark incomplete sections as ‘none’ or ‘no’"),
+            ("dropout", "No, screening cannot proceed"),
+        ),
+        required=True,
+        widget=forms.RadioSelect(),
+    )
+
+    def save(self):
+        pass
+
+
+class RecordMedicalInformationForm(forms.Form):
+    decision = forms.ChoiceField(
+        choices=(
+            ("continue", "Yes, go to medical information"),
+            ("dropout", "No, screening cannot proceed"),
+        ),
+        required=True,
+        widget=forms.RadioSelect(),
+    )
+
+    def save(self):
+        pass
+
+
+class AppointmentCannotGoAheadForm(forms.Form):
+    pass

--- a/manage_breast_screening/record_a_mammogram/tests/test_forms.py
+++ b/manage_breast_screening/record_a_mammogram/tests/test_forms.py
@@ -1,0 +1,9 @@
+from pytest_django.asserts import assertFormError
+
+from ..forms import ScreeningAppointmentForm
+
+
+class TestScreeningAppointmentForm:
+    def test_decision_cannot_be_left_blank(self):
+        form = ScreeningAppointmentForm({})
+        assertFormError(form, "decision", ["This field is required."])

--- a/manage_breast_screening/record_a_mammogram/tests/test_views.py
+++ b/manage_breast_screening/record_a_mammogram/tests/test_views.py
@@ -1,0 +1,24 @@
+from django.urls import reverse
+from pytest_django.asserts import assertContains, assertRedirects
+
+
+class TestStartScreening:
+    def test_appointment_continued(self, client):
+        response = client.post(
+            reverse("record_a_mammogram:start_screening"), {"decision": "continue"}
+        )
+        assertRedirects(
+            response, reverse("record_a_mammogram:ask_for_medical_information")
+        )
+
+    def test_appointment_stopped(self, client):
+        response = client.post(
+            reverse("record_a_mammogram:start_screening"), {"decision": "dropout"}
+        )
+        assertRedirects(
+            response, reverse("record_a_mammogram:appointment_cannot_go_ahead")
+        )
+
+    def test_renders_invalid_form(self, client):
+        response = client.post(reverse("record_a_mammogram:start_screening"), {})
+        assertContains(response, "There is a problem")

--- a/manage_breast_screening/record_a_mammogram/urls.py
+++ b/manage_breast_screening/record_a_mammogram/urls.py
@@ -3,7 +3,7 @@ from django.views.generic import RedirectView
 
 from . import forms, views
 
-app_name = "clinics"
+app_name = "record_a_mammogram"
 
 urlpatterns = [
     path(

--- a/manage_breast_screening/record_a_mammogram/urls.py
+++ b/manage_breast_screening/record_a_mammogram/urls.py
@@ -1,0 +1,31 @@
+from django.urls import path
+from django.views.generic import RedirectView
+
+from . import forms, views
+
+app_name = "clinics"
+
+urlpatterns = [
+    path(
+        "",
+        RedirectView.as_view(pattern_name="record_a_mammogram:start_screening"),
+        name="index",
+    ),
+    path("start-screening/", views.StartScreening.as_view(), name="start_screening"),
+    path(
+        "ask-for-medical-information/",
+        views.AskForMedicalInformation.as_view(),
+        name="ask_for_medical_information",
+    ),
+    path(
+        "record-medical-information/",
+        views.RecordMedicalInformation.as_view(),
+        name="record_medical_information",
+    ),
+    path("awaiting-images/", views.awaiting_images, name="awaiting_images"),
+    path(
+        "appointment-cannot-go-ahead/",
+        views.AppointmentCannotGoAhead.as_view(),
+        name="appointment_cannot_go_ahead",
+    ),
+]

--- a/manage_breast_screening/record_a_mammogram/views.py
+++ b/manage_breast_screening/record_a_mammogram/views.py
@@ -1,0 +1,61 @@
+import logging
+
+from django.shortcuts import redirect, render
+from django.views.generic import FormView
+
+from .forms import (
+    AppointmentCannotGoAheadForm,
+    AskForMedicalInformationForm,
+    RecordMedicalInformationForm,
+    ScreeningAppointmentForm,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class StartScreening(FormView):
+    template_name = "record_a_mammogram/start_screening.jinja"
+    form_class = ScreeningAppointmentForm
+
+    def form_valid(self, form):
+        form.save()
+
+        if form.cleaned_data["decision"] == "continue":
+            return redirect("record_a_mammogram:ask_for_medical_information")
+        else:
+            return redirect("record_a_mammogram:appointment_cannot_go_ahead")
+
+
+class AskForMedicalInformation(FormView):
+    template_name = "record_a_mammogram/ask_for_medical_information.jinja"
+    form_class = AskForMedicalInformationForm
+
+    def form_valid(self, form):
+        form.save()
+
+        if form.cleaned_data["decision"] == "continue":
+            return redirect("record_a_mammogram:record_medical_information")
+        else:
+            return redirect("record_a_mammogram:awaiting_images")
+
+
+class RecordMedicalInformation(FormView):
+    template_name = "record_a_mammogram/record_medical_information.jinja"
+    form_class = RecordMedicalInformationForm
+
+    def form_valid(self, form):
+        form.save()
+
+        if form.cleaned_data["decision"] == "continue":
+            return redirect("record_a_mammogram:awaiting_images")
+        else:
+            return redirect("record_a_mammogram:appointment_cannot_go_ahead")
+
+
+class AppointmentCannotGoAhead(FormView):
+    template_name = "record_a_mammogram/appointment_cannot_go_ahead.jinja"
+    form_class = AppointmentCannotGoAheadForm
+
+
+def awaiting_images(request):
+    return render(request, "record_a_mammogram/awaiting_images.jinja", {})

--- a/manage_breast_screening/templates/layout-app.html
+++ b/manage_breast_screening/templates/layout-app.html
@@ -1,6 +1,6 @@
-{% from 'components/header/macro.njk' import header %}
-{% from 'components/footer/macro.njk' import footer %}
-{%- from 'components/skip-link/macro.njk' import skipLink %}
+{% from 'components/header/macro.jinja' import header %}
+{% from 'components/footer/macro.jinja' import footer %}
+{%- from 'components/skip-link/macro.jinja' import skipLink %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -90,7 +90,25 @@
     <div class="nhsuk-width-container {{ containerClasses }}">
       {% block beforeContent %}{% endblock %}
       <main class="nhsuk-main-wrapper {{ mainClasses }}" id="maincontent" role="main">
-        {% block content %}{% endblock %}
+        {% block content %}
+        <div class="nhsuk-grid-row">
+          <div class="nhsuk-grid-column-two-thirds">
+            {% block messages %}
+              {#- TODO: show messages from django.contrib.messages -#}
+            {% endblock messages %}
+          </div>
+        </div>
+
+        <div class="nhsuk-grid-row">
+          <div class="nhsuk-grid-column-full">
+            {% block pageNavigation %}
+            {% endblock pageNavigation %}
+          </div>
+        </div>
+
+        {% block pageContent %}
+        {% endblock pageContent %}
+        {% endblock content %}
       </main>
     </div>
   {% endblock %}

--- a/manage_breast_screening/templates/record_a_mammogram/appointment_cannot_go_ahead.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/appointment_cannot_go_ahead.jinja
@@ -1,0 +1,3 @@
+{% extends "wizard_step.jinja" %}
+
+{% set title = "Appointment cannot go ahead" %}

--- a/manage_breast_screening/templates/record_a_mammogram/ask_for_medical_information.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/ask_for_medical_information.jinja
@@ -1,0 +1,4 @@
+{% extends "wizard_step.jinja" %}
+
+{% set title = "Medical information" %}
+{% set decision_legend = "Has the participant shared any relevant medical information?" %}

--- a/manage_breast_screening/templates/record_a_mammogram/awaiting_images.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/awaiting_images.jinja
@@ -1,0 +1,3 @@
+{% extends "wizard_step.jinja" %}
+
+{% set title = "Awaiting images" %}

--- a/manage_breast_screening/templates/record_a_mammogram/record_medical_information.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/record_medical_information.jinja
@@ -1,0 +1,4 @@
+{% extends "wizard_step.jinja" %}
+
+{% set title = "Record medical information" %}
+{% set decision_legend = "Can imaging go ahead?" %}

--- a/manage_breast_screening/templates/record_a_mammogram/start_screening.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/start_screening.jinja
@@ -1,0 +1,5 @@
+{% extends "wizard_step.jinja" %}
+
+{% set title = "Screening appointment" %}
+{% set decision_legend = "Can the appointment go ahead?" %}
+{% set decision_hint = "Before you proceed, check the participant’s identity and confirm that their last mammogram was more than 6 months ago." %}

--- a/manage_breast_screening/templates/wizard_step.jinja
+++ b/manage_breast_screening/templates/wizard_step.jinja
@@ -1,0 +1,81 @@
+{% extends 'layout-app.html' %}
+{% from 'components/radios/macro.jinja' import radios %}
+{% from 'components/button/macro.jinja' import button %}
+{% from 'components/fieldset/macro.jinja' import fieldset %}
+{% from 'components/back-link/macro.jinja' import backLink %}
+{% from 'components/error-summary/macro.jinja' import errorSummary %}
+
+{% block beforeContent %}
+{#- Using javascript temporarily - this should be replaced with proper URLs -#}
+{{ backLink({
+  "href": "javascript:history.back()",
+  "text": "Go back"
+}) }}
+{% endblock beforeContent %}
+
+{% block messages %}
+    {% if form.errors %}
+      {% set ns = namespace(errors=[]) %}
+
+      {% for field, messages in form.errors | items %}
+        {% set ns.errors = ns.errors + [{"text": ",".join(messages), "href": "#" ~ field ~ "-error"}] %}
+      {% endfor %}
+
+      {{ errorSummary({
+        "titleText": "There is a problem",
+        "errorList": ns.errors
+      }) }}
+    {% endif %}
+{% endblock %}
+
+{% block pageContent %}
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-full">
+  <h1>{{title}}</h1>
+
+  {% if form %}
+  <form action="{{request.path}}" method="POST">
+  {% block form %}{% endblock form %}
+
+  {% if form.decision %}
+    {% if form.decision.errors %}
+      {% set errorMessage = {"text": form.decision.errors | first} %}
+    {% endif %}
+
+    {{ radios({
+      "name": form.decision.html_name,
+      "fieldset": {
+        "legend": {
+          "text": decision_legend,
+          "classes": "nhsuk-fieldset__legend--m",
+          "isPageHeading": false
+        }
+      },
+      "errorMessage": errorMessage,
+      "hint": {
+        html: decision_hint|e
+      },
+      "items": [
+        {
+          "value": "continue",
+          "text": form.decision[0].choice_label
+        },
+        {
+          "value": "dropout",
+          "text": form.decision[1].choice_label
+        }
+      ]
+    }) }}
+  {% endif %}
+
+  {{ button({
+    "text": "Save and continue"
+  }) }}
+
+  {{csrf_input}}
+  </form>
+
+  {% endif %}
+  </div>
+</div>
+{% endblock pageContent %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,14 @@ authors = [{ name = "Your Name", email = "you@example.com" }]
 license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.13"
-dependencies = ["django (>=5.1.7,<6.0.0)", "dotenv (>=0.9.9,<0.10.0)", "gunicorn (>=23.0.0,<24.0.0)", "jinja2 (>=3.1.6,<4.0.0)", "whitenoise[brotli] (>=6.9.0,<7.0.0)", "nhsuk-frontend-jinja @ git+https://github.com/NHSDigital/nhsuk-frontend-jinja.git@0.1.0"]
+dependencies = [
+  "django (>=5.1.7,<6.0.0)",
+  "dotenv (>=0.9.9,<0.10.0)",
+  "gunicorn (>=23.0.0,<24.0.0)",
+  "jinja2 (>=3.1.6,<4.0.0)",
+  "whitenoise[brotli] (>=6.9.0,<7.0.0)",
+  "nhsuk-frontend-jinja @ git+https://github.com/NHSDigital/nhsuk-frontend-jinja.git@0.1.0",
+]
 
 [tool.poetry]
 package-mode = false
@@ -23,5 +30,5 @@ build-backend = "poetry.core.masonry.api"
 
 
 [tool.pytest.ini_options]
-DJANGO_SETTINGS_MODULE = "manage_breast_screening.config.settings"
+DJANGO_SETTINGS_MODULE = "manage_breast_screening.config.settings_test"
 python_files = "tests.py test_*.py *_tests.py"


### PR DESCRIPTION
## Description

This supercedes https://github.com/NHSDigital/manage-breast-screening/pull/18

We're thinking that each step in the form will persist progress to the database. There will likely be some duplication/boilerplate in the view layer, but we will address this later if it becomes difficult to work with.

## Context

The record a mammogram journey is a multi-step journey where steps can be skipped based on the information submitted. We want to set up a basic template so that we can start working on the individual pages and aligning them with the [prototype](https://github.com/NHSDigital/manage-breast-screening-prototype/tree/main/app/views/events/mammography).

## Type of changes

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
