### PR TITLE
Swap to using inbuilt NHS class rather than custom class

### DIFF
--- a/manage_breast_screening/assets/sass/main.scss
+++ b/manage_breast_screening/assets/sass/main.scss
@@ -17,10 +17,6 @@ h3 {
   @extend %nhsuk-heading-s;
 }
 
-.app-nowrap {
-  white-space: nowrap;
-}
-
 .app-text-grey {
   color: $nhsuk-secondary-text-color;
 }

--- a/manage_breast_screening/config/jinja2_env.py
+++ b/manage_breast_screening/config/jinja2_env.py
@@ -5,7 +5,7 @@ from markupsafe import Markup, escape
 
 
 def no_wrap(value):
-    return Markup(f'<span class="app-nowrap">{escape(value)}</span>' if value else "")
+    return Markup(f'<span class="nhsuk-u-nowrap">{escape(value)}</span>' if value else "")
 
 
 def as_hint(value):


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Unbenownst to me, NHS Frontend already includes a no-wrap class.

## Type of changes

- [x] Refactoring (non-breaking change)


## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
