### PR TITLE
Appointment secondary navigation

### DIFF
--- a/manage_breast_screening/record_a_mammogram/views.py
+++ b/manage_breast_screening/record_a_mammogram/views.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.views.decorators.http import require_http_methods
 from django.views.generic import FormView
 
@@ -62,6 +63,12 @@ class StartScreening(FormView):
             "key": appointment.status,
         }
         context["Status"] = Status
+
+        if appointment.status in [
+            appointment.Status.SCREENED,
+            appointment.Status.PARTIALLY_SCREENED,
+        ]:
+            context["secondary_nav_items"] = build_secondary_nav(appointment.pk)
 
         last_known_screening = appointment.screening_episode.previous()
 
@@ -127,3 +134,19 @@ def check_in(request, id):
     appointment.save()
 
     return redirect("record_a_mammogram:start_screening", id=id)
+
+
+def build_secondary_nav(id):
+    """
+    Build a secondary nav for reviewing the information of screened/partially screened appointments.
+    """
+    return [
+        {
+            "id": "all",
+            "text": "Appointment details",
+            "href": reverse("record_a_mammogram:start_screening", kwargs={"id": id}),
+            "current": True,
+        },
+        {"id": "medical_information", "text": "Medical information", "href": "#"},
+        {"id": "images", "text": "Images", "href": "#"},
+    ]

--- a/manage_breast_screening/templates/record_a_mammogram/start_screening.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/start_screening.jinja
@@ -36,8 +36,8 @@
 
   {% if secondary_nav_items %}
     {{ appSecondaryNavigation({
-    "visuallyHiddenTitle": "Secondary menu",
-    "items": secondary_nav_items
+      "visuallyHiddenTitle": "Secondary menu",
+      "items": secondary_nav_items
     }) }}
   {% endif %}
 

--- a/manage_breast_screening/templates/record_a_mammogram/start_screening.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/start_screening.jinja
@@ -4,6 +4,7 @@
 {% from '_components/appointment-status/macro.jinja' import appointmentStatus %}
 {% from '_components/appointment-header/macro.jinja' import appointmentHeader %}
 {% from '_components/participant-details/macro.jinja' import participantDetails %}
+{% from '_components/secondary-navigation/macro.jinja' import appSecondaryNavigation %}
 
 {% set caption = clinic_slot.clinic.get_type_display() | capitalize ~ " appointment" %}
 {% set title = participant.first_name ~ " " ~ participant.last_name %}
@@ -32,6 +33,13 @@
 
 {% block stepContent %}
   {{ appointmentHeader(appointment) }}
+
+  {% if secondary_nav_items %}
+    {{ appSecondaryNavigation({
+    "visuallyHiddenTitle": "Secondary menu",
+    "items": secondary_nav_items
+    }) }}
+  {% endif %}
 
   {% set specialAppointmentHtml %}
     {% if participant.extra_needs | length > 1 %}


### PR DESCRIPTION
## Description

This adds the secondary navigation component. It's currently non-functional as we haven't built the other pages.

![Screenshot showing the 3 tabs: "Appointment details", "Medical information", "Images"](https://github.com/user-attachments/assets/156ece91-eae8-4409-a711-6f71cfce5d3e)

## Context

When the appointment reaches a screened or partially screened state, the user will be able to navigate to any of these stages, so they can review the information.

Even though it's not functional yet, I'm adding it now so we have the basic layout in place.

## Type of changes
- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
