### PR TITLE
Ask for medical information page

### DIFF
--- a/manage_breast_screening/record_a_mammogram/forms.py
+++ b/manage_breast_screening/record_a_mammogram/forms.py
@@ -18,8 +18,8 @@ class ScreeningAppointmentForm(forms.Form):
 class AskForMedicalInformationForm(forms.Form):
     decision = forms.ChoiceField(
         choices=(
-            ("continue", "Yes"),
-            ("dropout", "No - proceed to imaging"),
+            ("yes", "Yes"),
+            ("no", "No - proceed to imaging"),
         ),
         required=True,
         widget=forms.RadioSelect(),

--- a/manage_breast_screening/record_a_mammogram/views.py
+++ b/manage_breast_screening/record_a_mammogram/views.py
@@ -196,6 +196,7 @@ def appointment_cannot_go_ahead(request, id):
             "title": "Appointment cannot go ahead",
             "caption": participant.full_name,
             "form": form,
+            "decision_legend": "Does the appointment need to be rescheduled?",
         },
     )
 

--- a/manage_breast_screening/record_a_mammogram/views.py
+++ b/manage_breast_screening/record_a_mammogram/views.py
@@ -6,6 +6,7 @@ from django.views.decorators.http import require_http_methods
 from django.views.generic import FormView
 
 from manage_breast_screening.clinics.models import Appointment
+from manage_breast_screening.participants.models import Participant
 
 from ..clinics.models import Appointment
 from .forms import (
@@ -17,6 +18,8 @@ from .forms import (
 from .presenters import AppointmentPresenter, present_secondary_nav
 
 Status = Appointment.Status
+
+APPOINTMENT_CANNOT_PROCEED = "Appointment cannot proceed"
 
 logger = logging.getLogger(__name__)
 
@@ -111,12 +114,35 @@ class AskForMedicalInformation(BaseAppointmentForm):
         )
         return context
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        id = self.kwargs["id"]
+        participant = Participant.objects.get(screeningepisode__appointment__id=id)
+
+        context.update(
+            {
+                "participant": participant,
+                "caption": participant.full_name,
+                "title": "Medical information",
+                "decision_legend": "Has the participant shared any relevant medical information?",
+                "cannot_continue_link": {
+                    "href": reverse(
+                        "record_a_mammogram:appointment_cannot_go_ahead",
+                        kwargs={"id": id},
+                    ),
+                    "text": APPOINTMENT_CANNOT_PROCEED,
+                },
+            }
+        )
+
+        return context
+
     def form_valid(self, form):
         form.save()
 
         appointment = self.get_appointment()
 
-        if form.cleaned_data["decision"] == "continue":
+        if form.cleaned_data["decision"] == "yes":
             return redirect(
                 "record_a_mammogram:record_medical_information", id=appointment.pk
             )

--- a/manage_breast_screening/templates/record_a_mammogram/ask_for_medical_information.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/ask_for_medical_information.jinja
@@ -1,2 +1,13 @@
 {% extends "wizard_step.jinja" %}
 
+{% block stepContent %}
+  <p>Ask them about any:</p>
+  <ul class="nhsuk-list nhsuk-list--bullet">
+    <li>history of breast cancer</li>
+    <li>lump examinations or biopsies</li>
+    <li>other procedures in the breast or chest area</li>
+    <li>recent breast changes or symptoms</li>
+    <li>breast features (such as moles) that may appear on an x-ray</li>
+    <li>relevant medication (such as HRT)</li>
+  </ul>
+{% endblock %}

--- a/manage_breast_screening/templates/wizard_step.jinja
+++ b/manage_breast_screening/templates/wizard_step.jinja
@@ -93,7 +93,7 @@
   {% endif %}
 
   {% if cannot_continue_link %}
-    <p class="nhsuk-u-margin-top-x9"><a class="nhsuk-link nhsuk-link--no-visited-state" href="{{ cannot_continue_link.href }}">{{ cannot_continue_link.text }}</a></p>
+    <p><a class="nhsuk-link nhsuk-link--no-visited-state" href="{{ cannot_continue_link.href }}">{{ cannot_continue_link.text }}</a></p>
   {% endif %}
   </div>
 

--- a/manage_breast_screening/templates/wizard_step.jinja
+++ b/manage_breast_screening/templates/wizard_step.jinja
@@ -66,7 +66,7 @@
               "errorMessage": errorMessage,
               "hint": {
                 "html": decision_hint|e
-              },
+              } if decision_hint,
               "items": [
                 {
                   "value": form.decision.field.choices[0][0],

--- a/manage_breast_screening/templates/wizard_step.jinja
+++ b/manage_breast_screening/templates/wizard_step.jinja
@@ -90,8 +90,12 @@
         </div>
     </div>
   </form>
+  {% endif %}
 
+  {% if cannot_continue_link %}
+    <p class="nhsuk-u-margin-top-x9"><a class="nhsuk-link nhsuk-link--no-visited-state" href="{{ cannot_continue_link.href }}">{{ cannot_continue_link.text }}</a></p>
   {% endif %}
   </div>
+
 </div>
 {% endblock pageContent %}


### PR DESCRIPTION
This implements the second page in the record a mammogram journey.

![Screenshot showing the ask for medical information page. ](https://github.com/user-attachments/assets/8fa3808a-4092-4cc9-92f2-6254d7bdd974)

https://github.com/NHSDigital/manage-breast-screening/pull/54 needs merging before this one

This adds the following copy (taken from the prototype)

Ask them about any:

- history of breast cancer
- lump examinations or biopsies
- other procedures in the breast or chest area
- recent breast changes or symptoms
- breast features (such as moles) that may appear on an x-ray
- relevant medication (such as HRT)
