### PR TITLE
Extract a presenter (view model) layer

### DIFF
--- a/manage_breast_screening/clinics/presenters.py
+++ b/manage_breast_screening/clinics/presenters.py
@@ -1,0 +1,46 @@
+from ..utils.date_formatting import format_date, format_time_range
+from ..utils.string_formatting import sentence_case
+from .models import Clinic
+
+
+class ClinicsPresenter:
+    def __init__(self, filtered_clinics, filter, counts_by_filter):
+        self.clinics = [ClinicPresenter(clinic) for clinic in filtered_clinics]
+        self.counts_by_filter = counts_by_filter
+        self.filter = filter
+
+    @property
+    def heading(self):
+        if self.filter == "today":
+            return "Today’s clinics"
+        elif self.filter == "upcoming":
+            return "Upcoming clinics"
+        elif self.filter == "completed":
+            return "Completed clinics this week"
+        else:
+            return "All clinics this week"
+
+
+class ClinicPresenter:
+    STATUS_COLORS = {
+        Clinic.State.SCHEDULED: "blue",  # default blue
+        Clinic.State.IN_PROGRESS: "blue",
+        Clinic.State.CLOSED: "grey",
+    }
+
+    def __init__(self, clinic):
+        self._clinic = clinic
+        self.starts_at = format_date(clinic.starts_at)
+        self.session_type = clinic.session_type().capitalize()
+        self.number_of_slots = clinic.clinic_slots.count()
+        self.location_name = sentence_case(clinic.setting.name)
+        self.time_range = format_time_range(clinic.time_range())
+        self.type = clinic.get_type_display()
+        self.risk_type = clinic.get_risk_type_display()
+
+    @property
+    def state(self):
+        return {
+            "text": self._clinic.get_state_display(),
+            "classes": "nhsuk-tag--" + self.STATUS_COLORS[self._clinic.state],
+        }

--- a/manage_breast_screening/clinics/tests/test_presenters.py
+++ b/manage_breast_screening/clinics/tests/test_presenters.py
@@ -1,0 +1,38 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from manage_breast_screening.clinics.presenters import ClinicPresenter
+
+from ..models import Clinic
+
+
+@pytest.fixture
+def mock_clinic():
+    mock = MagicMock(spec=Clinic)
+
+    mock.starts_at = datetime(2025, 1, 1, 9)
+    mock.session_type.return_value = "All day"
+    mock.clinic_slots.count.return_value = 10
+    mock.setting.name = "Test setting"
+    mock.time_range.return_value = {
+        "start_time": datetime(2025, 1, 1, 9),
+        "end_time": datetime(2025, 1, 1, 15),
+    }
+    mock.get_type_display.return_value = "Screening"
+    mock.get_risk_type_display.return_value = "Routine"
+
+    return mock
+
+
+def test_clinic_presenter(mock_clinic):
+    presenter = ClinicPresenter(mock_clinic)
+
+    assert presenter.starts_at == "1 January 2025"
+    assert presenter.session_type == "All day"
+    assert presenter.number_of_slots == 10
+    assert presenter.location_name == "Test setting"
+    assert presenter.time_range == "9am to 3pm"
+    assert presenter.type == "Screening"
+    assert presenter.risk_type == "Routine"

--- a/manage_breast_screening/config/jinja2_env.py
+++ b/manage_breast_screening/config/jinja2_env.py
@@ -6,14 +6,6 @@ from django.urls import reverse
 from jinja2 import ChoiceLoader, Environment, PackageLoader
 from markupsafe import Markup, escape
 
-from ..utils.date_formatting import (
-    format_date,
-    format_date_time,
-    format_relative_date,
-    format_time,
-    format_time_range,
-)
-
 
 def no_wrap(value):
     """
@@ -54,10 +46,7 @@ def environment(**options):
     env.globals.update(
         {"static": static, "url": reverse, "STATIC_URL": settings.STATIC_URL}
     )
+    env.filters["no_wrap"] = no_wrap
     env.filters["as_hint"] = as_hint
-
-    # TODO: format all dates and times in the presenter layer
-    env.filters["format_date"] = format_date
-    env.filters["format_time_range"] = format_time_range
 
     return env

--- a/manage_breast_screening/config/jinja2_env.py
+++ b/manage_breast_screening/config/jinja2_env.py
@@ -37,44 +37,6 @@ def as_hint(value):
     return Markup(f'<span class="app-text-grey">{value}</span>' if value else "")
 
 
-def sentence_case(value):
-    """
-    Capitalise the first letter of a sentence.
-
-    >>> sentence_case('a quick brown fox jumps over the lazy dog')
-    'A quick brown fox jumps over the lazy dog'
-
-    Unlike the built in `capitalize` filter, this will preserve
-    capital letters already in the string:
-
-    >>> sentence_case('not in PACS')
-    'Not in PACS'
-    """
-    if not value:
-        return ""
-
-    return value[0].upper() + value[1:]
-
-
-def format_nhs_number(value):
-    """
-    Format an NHS number with spaces
-
-    >>> format_nhs_number('9998887777')
-    '999 888 7777'
-    """
-    if not value:
-        return ""
-
-    digits = re.sub(r"\s", "", value)
-
-    return f"{digits[:3]} {digits[3:6]} {digits[6:]}"
-
-
-def format_age(value: int) -> str:
-    return f"{value} years old"
-
-
 def environment(**options):
     env = Environment(**options, extensions=["jinja2.ext.do"])
     if env.loader:
@@ -92,14 +54,10 @@ def environment(**options):
     env.globals.update(
         {"static": static, "url": reverse, "STATIC_URL": settings.STATIC_URL}
     )
-    env.filters["noWrap"] = no_wrap
-    env.filters["asHint"] = as_hint
-    env.filters["formatAge"] = format_age
-    env.filters["formatDate"] = format_date
-    env.filters["formatDateTime"] = format_date_time
-    env.filters["formatNhsNumber"] = format_nhs_number
-    env.filters["formatRelativeDate"] = format_relative_date
-    env.filters["formatTimeRange"] = format_time_range
-    env.filters["formatTimeString"] = format_time
-    env.filters["sentenceCase"] = sentence_case
+    env.filters["as_hint"] = as_hint
+
+    # TODO: format all dates and times in the presenter layer
+    env.filters["format_date"] = format_date
+    env.filters["format_time_range"] = format_time_range
+
     return env

--- a/manage_breast_screening/record_a_mammogram/presenters.py
+++ b/manage_breast_screening/record_a_mammogram/presenters.py
@@ -4,46 +4,9 @@ from django.urls import reverse
 
 from ..clinics.models import Appointment
 from ..utils.date_formatting import format_date, format_relative_date, format_time
+from ..utils.string_formatting import format_age, format_nhs_number, sentence_case
 
 Status = Appointment.Status
-
-
-def sentence_case(value):
-    """
-    Capitalise the first letter of a sentence.
-
-    >>> sentence_case('a quick brown fox jumps over the lazy dog')
-    'A quick brown fox jumps over the lazy dog'
-
-    Unlike the built in `capitalize` filter, this will preserve
-    capital letters already in the string:
-
-    >>> sentence_case('not in PACS')
-    'Not in PACS'
-    """
-    if not value:
-        return ""
-
-    return value[0].upper() + value[1:]
-
-
-def format_nhs_number(value):
-    """
-    Format an NHS number with spaces
-
-    >>> format_nhs_number('9998887777')
-    '999 888 7777'
-    """
-    if not value:
-        return ""
-
-    digits = re.sub(r"\s", "", value)
-
-    return f"{digits[:3]} {digits[3:6]} {digits[6:]}"
-
-
-def format_age(value: int) -> str:
-    return f"{value} years old"
 
 
 def status_colour(status):

--- a/manage_breast_screening/record_a_mammogram/presenters.py
+++ b/manage_breast_screening/record_a_mammogram/presenters.py
@@ -1,0 +1,168 @@
+import re
+
+from django.urls import reverse
+
+from ..clinics.models import Appointment
+from ..utils.date_formatting import format_date, format_relative_date, format_time
+
+Status = Appointment.Status
+
+
+def sentence_case(value):
+    """
+    Capitalise the first letter of a sentence.
+
+    >>> sentence_case('a quick brown fox jumps over the lazy dog')
+    'A quick brown fox jumps over the lazy dog'
+
+    Unlike the built in `capitalize` filter, this will preserve
+    capital letters already in the string:
+
+    >>> sentence_case('not in PACS')
+    'Not in PACS'
+    """
+    if not value:
+        return ""
+
+    return value[0].upper() + value[1:]
+
+
+def format_nhs_number(value):
+    """
+    Format an NHS number with spaces
+
+    >>> format_nhs_number('9998887777')
+    '999 888 7777'
+    """
+    if not value:
+        return ""
+
+    digits = re.sub(r"\s", "", value)
+
+    return f"{digits[:3]} {digits[3:6]} {digits[6:]}"
+
+
+def format_age(value: int) -> str:
+    return f"{value} years old"
+
+
+def status_colour(status):
+    """
+    Color to render the status tag
+    """
+    match status:
+        case Status.CHECKED_IN:
+            return ""  # no colour will get solid dark blue
+        case Status.SCREENED:
+            return "green"
+        case Status.DID_NOT_ATTEND | Status.CANCELLED:
+            return "red"
+        case Status.ATTENDED_NOT_SCREENED | Status.PARTIALLY_SCREENED:
+            return "orange"
+        case _:
+            return "blue"  # default blue
+
+
+def present_secondary_nav(id):
+    """
+    Build a secondary nav for reviewing the information of screened/partially screened appointments.
+    """
+    return [
+        {
+            "id": "all",
+            "text": "Appointment details",
+            "href": reverse("record_a_mammogram:start_screening", kwargs={"id": id}),
+            "current": True,
+        },
+        {"id": "medical_information", "text": "Medical information", "href": "#"},
+        {"id": "images", "text": "Images", "href": "#"},
+    ]
+
+
+class AppointmentPresenter:
+    def __init__(self, appointment):
+        self._appointment = appointment
+        self._last_known_screening = appointment.screening_episode.previous()
+
+        self.allStatuses = Status
+        self.id = appointment.id
+        self.clinic_slot = ClinicSlotPresenter(appointment.clinic_slot)
+        self.participant = ParticipantPresenter(
+            appointment.screening_episode.participant
+        )
+
+    @property
+    def status(self):
+        colour = status_colour(self._appointment.status)
+
+        return {
+            "classes": f"nhsuk-tag--{colour} app-nowrap" if colour else "app-nowrap",
+            "text": self._appointment.get_status_display(),
+            "key": self._appointment.status,
+            "is_confirmed": self._appointment.status == Status.CONFIRMED,
+        }
+
+    @property
+    def last_known_screening(self):
+        return (
+            {
+                "date": format_date(self._last_known_screening.created_at),
+                "relative_date": format_relative_date(
+                    self._last_known_screening.created_at
+                ),
+                # TODO: the current model doesn't allow for knowing the type and location of a historical screening
+                # if it is not tied to one of our clinic slots.
+                "location": None,
+                "type": None,
+            }
+            if self._last_known_screening
+            else {}
+        )
+
+
+class ClinicSlotPresenter:
+    def __init__(self, clinic_slot):
+        self._clinic_slot = clinic_slot
+        self._clinic = clinic_slot.clinic
+
+        self.clinic_id = self._clinic.id
+
+    @property
+    def clinic_type(self):
+        return self._clinic.get_type_display().capitalize()
+
+    @property
+    def slot_time_and_clinic_date(self):
+        clinic_slot = self._clinic_slot
+        clinic = self._clinic
+
+        return f"{format_time(clinic_slot.starts_at)} ({ clinic_slot.duration_in_minutes } minutes) - { format_date(clinic.starts_at) } ({ format_relative_date(clinic.starts_at) })"
+
+
+class ParticipantPresenter:
+    def __init__(self, participant):
+        self._participant = participant
+
+        self.extra_needs = participant.extra_needs
+        self.ethnic_group = participant.ethnic_group
+        self.full_name = participant.full_name
+        self.nhs_number = format_nhs_number(participant.nhs_number)
+        self.date_of_birth = format_date(participant.date_of_birth)
+        self.age = format_age(participant.age())
+        self.risk_level = sentence_case(participant.risk_level)
+
+    @property
+    def ethnic_group_category(self):
+        category = self._participant.ethnic_group_category()
+        if category:
+            return category.replace("Any other", "any other")
+        else:
+            return None
+
+    @property
+    def address(self):
+        address = self._participant.address
+        if not address:
+            return {}
+
+        return {"lines": address.lines, "postcode": address.postcode}

--- a/manage_breast_screening/record_a_mammogram/tests/test_presenters.py
+++ b/manage_breast_screening/record_a_mammogram/tests/test_presenters.py
@@ -1,0 +1,133 @@
+from datetime import date, datetime
+from datetime import timezone as tz
+from unittest.mock import MagicMock
+
+import pytest
+import time_machine
+
+from manage_breast_screening.clinics.models import (
+    Appointment,
+    ClinicSlot,
+    ScreeningEpisode,
+)
+from manage_breast_screening.clinics.tests.factories import AppointmentFactory
+from manage_breast_screening.participants.models import Participant
+
+from ..presenters import AppointmentPresenter, ClinicSlotPresenter, ParticipantPresenter
+
+
+class TestAppointmentPresenter:
+    @pytest.fixture
+    def mock_appointment(self):
+        mock = MagicMock(spec=Appointment)
+        mock.screening_episode.participant.nhs_number = "99900900829"
+        return mock
+
+    @pytest.mark.parametrize(
+        "status, expected_classes, expected_text, expected_key, expected_is_confirmed",
+        [
+            (
+                Appointment.Status.CONFIRMED,
+                "nhsuk-tag--blue app-nowrap",
+                "Confirmed",
+                "CONFIRMED",
+                True,
+            ),
+            (
+                Appointment.Status.CHECKED_IN,
+                "app-nowrap",
+                "Checked in",
+                "CHECKED_IN",
+                False,
+            ),
+            (
+                Appointment.Status.ATTENDED_NOT_SCREENED,
+                "nhsuk-tag--orange app-nowrap",
+                "Attended not screened",
+                "ATTENDED_NOT_SCREENED",
+                False,
+            ),
+        ],
+    )
+    def test_status(
+        self,
+        mock_appointment,
+        status,
+        expected_classes,
+        expected_text,
+        expected_key,
+        expected_is_confirmed,
+    ):
+        mock_appointment.status = status
+        mock_appointment.get_status_display.return_value = Appointment.STATUS_CHOICES[
+            status
+        ]
+
+        result = AppointmentPresenter(mock_appointment).status
+
+        assert result["classes"] == expected_classes
+        assert result["text"] == expected_text
+        assert result["key"] == expected_key
+        assert result["is_confirmed"] == expected_is_confirmed
+
+    @time_machine.travel(datetime(2025, 1, 1, tzinfo=tz.utc))
+    def test_last_known_screening(self, mock_appointment):
+        mock_screening = MagicMock(spec=ScreeningEpisode)
+        mock_screening.created_at = datetime(2015, 1, 1)
+        mock_appointment.screening_episode.previous.return_value = mock_screening
+
+        result = AppointmentPresenter(mock_appointment)
+
+        assert result.last_known_screening == {
+            "date": "1 January 2015",
+            "relative_date": "10 years ago",
+            "location": None,
+            "type": None,
+        }
+
+
+class TestClinicSlotPresenter:
+    @pytest.fixture
+    def clinic_slot_mock(self):
+        mock = MagicMock(spec=ClinicSlot)
+        return mock
+
+    def test_clinic_type(self, clinic_slot_mock):
+        clinic_slot_mock.clinic.get_type_display.return_value = "Screening"
+
+        assert ClinicSlotPresenter(clinic_slot_mock).clinic_type == "Screening"
+
+    @time_machine.travel(datetime(2025, 5, 19, tzinfo=tz.utc))
+    def test_slot_time_and_clinic_date(self, clinic_slot_mock):
+        clinic_slot_mock.starts_at = datetime(2025, 1, 2, 9, 30)
+        clinic_slot_mock.duration_in_minutes = 30
+        clinic_slot_mock.clinic.starts_at = date(2025, 1, 2)
+
+        assert (
+            ClinicSlotPresenter(clinic_slot_mock).slot_time_and_clinic_date
+            == "9:30am (30 minutes) - 2 January 2025 (4 months, 17 days ago)"
+        )
+
+
+class TestParticipantPresenter:
+    @pytest.fixture
+    def mock_participant(self):
+        mock = MagicMock(spec=Participant)
+        mock.nhs_number = "99900900829"
+        return mock
+
+    @pytest.mark.parametrize(
+        "category, formatted",
+        [
+            (
+                "Black, African, Caribbean or Black British",
+                "Black, African, Caribbean or Black British",
+            ),
+            (None, None),
+            ("Any other", "any other"),
+        ],
+    )
+    def test_ethnic_group_category(self, mock_participant, category, formatted):
+        mock_participant.ethnic_group_category.return_value = category
+        result = ParticipantPresenter(mock_participant)
+        assert result.ethnic_group_category == formatted

--- a/manage_breast_screening/record_a_mammogram/views.py
+++ b/manage_breast_screening/record_a_mammogram/views.py
@@ -66,9 +66,9 @@ class StartScreening(BaseAppointmentForm):
 
         context.update(
             {
-                "appointment": presenter,
-                "caption": presenter.clinic_slot.clinic_type + " appointment",
                 "title": presenter.participant.full_name,
+                "caption": presenter.clinic_slot.clinic_type + " appointment",
+                "appointment": presenter,
                 "decision_legend": "Can the appointment go ahead?",
                 "decision_hint": "Before you proceed, check the participant’s identity and confirm that their last mammogram was more than 6 months ago.",
             }
@@ -101,6 +101,16 @@ class AskForMedicalInformation(BaseAppointmentForm):
     template_name = "record_a_mammogram/ask_for_medical_information.jinja"
     form_class = AskForMedicalInformationForm
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "title": "Medical information",
+                "decision_legend": "Has the participant shared any relevant medical information?",
+            }
+        )
+        return context
+
     def form_valid(self, form):
         form.save()
 
@@ -118,6 +128,16 @@ class RecordMedicalInformation(BaseAppointmentForm):
     template_name = "record_a_mammogram/record_medical_information.jinja"
     form_class = RecordMedicalInformationForm
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "title": "Record medical information",
+                "decision_legend": "Can imaging go ahead?",
+            }
+        )
+        return context
+
     def form_valid(self, form):
         form.save()
 
@@ -134,6 +154,7 @@ class RecordMedicalInformation(BaseAppointmentForm):
 def appointment_cannot_go_ahead(request, id):
     appointment = get_object_or_404(Appointment, pk=id)
     participant = appointment.screening_episode.participant
+
     if request.method == "POST":
         form = AppointmentCannotGoAheadForm(request.POST, instance=appointment)
         if form.is_valid():
@@ -145,12 +166,20 @@ def appointment_cannot_go_ahead(request, id):
     return render(
         request,
         "record_a_mammogram/appointment_cannot_go_ahead.jinja",
-        {"form": form, "participant": participant},
+        {
+            "title": "Appointment cannot go ahead",
+            "caption": participant.full_name,
+            "form": form,
+        },
     )
 
 
 def awaiting_images(request, id):
-    return render(request, "record_a_mammogram/awaiting_images.jinja", {})
+    return render(
+        request,
+        "record_a_mammogram/awaiting_images.jinja",
+        {"title": "Awaiting images"},
+    )
 
 
 @require_http_methods(["POST"])

--- a/manage_breast_screening/templates/_components/appointment-header/macro.jinja
+++ b/manage_breast_screening/templates/_components/appointment-header/macro.jinja
@@ -1,3 +1,3 @@
-{% macro appointmentHeader(appointment) %}
+{% macro appointment_header(appointment) %}
   {%- include '_components/appointment-header/template.jinja' -%}
 {% endmacro %}

--- a/manage_breast_screening/templates/_components/appointment-header/template.jinja
+++ b/manage_breast_screening/templates/_components/appointment-header/template.jinja
@@ -1,9 +1,8 @@
 {% set clinic_slot = appointment.clinic_slot %}
-{% set clinic = clinic_slot.clinic %}
-{% set participant = appointment.screening_episode.participant %}
+{% set participant = appointment.participant %}
 
-<p class="app-text-grey"><span>NHS Number: {{ participant.nhs_number | formatNhsNumber }}</span></p>
+<p class="app-text-grey"><span>NHS Number: {{ participant.nhs_number }}</span></p>
 
-<p>{{ clinic_slot.starts_at | formatTimeString }} ({{ clinic_slot.duration_in_minutes }} minutes) - {{ clinic.starts_at | formatDate }} ({{ clinic.starts_at | formatRelativeDate }})<span class="nhsuk-u-margin-left-3"><a href="#">Reschedule appointment</a></span></p>
+<p>{{ clinic_slot.slot_time_and_clinic_date }}<span class="nhsuk-u-margin-left-3"><a href="#">Reschedule appointment</a></span></p>
 
 <p class="nhsuk-u-margin-bottom-4"><a href="#">View participant record</a></p>

--- a/manage_breast_screening/templates/_components/appointment-status/macro.jinja
+++ b/manage_breast_screening/templates/_components/appointment-status/macro.jinja
@@ -1,3 +1,3 @@
-{% macro appointmentStatus(params) %}
+{% macro appointment_status(appointment, csrf_input) %}
   {%- include '_components/appointment-status/template.jinja' -%}
 {% endmacro %}

--- a/manage_breast_screening/templates/_components/appointment-status/template.jinja
+++ b/manage_breast_screening/templates/_components/appointment-status/template.jinja
@@ -9,7 +9,7 @@
   })}}
 
   {% if appointment.status.is_confirmed %}
-    <form action="{{ url('record_a_mammogram:check_in', kwargs={'id': appointment.id}) }}" <form method="post" novalidate>
+    <form action="{{ url('record_a_mammogram:check_in', kwargs={'id': appointment.id}) }}" method="post" novalidate>
     <p class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-0">
       <button class="app-button--link">
         Check in

--- a/manage_breast_screening/templates/_components/appointment-status/template.jinja
+++ b/manage_breast_screening/templates/_components/appointment-status/template.jinja
@@ -2,23 +2,20 @@
 
 {% set colors = {} %}
 
-{% set tagClasses = "nhsuk-tag--" ~ params.status.colour if params.status.colour else "" %}
-{% set tagClasses = tagClasses + " app-nowrap" %}
-
 <div data-event-status-container="{{ params.id }}">
   {{ tag({
-    "text": params.status.text,
-    "classes": tagClasses
+    "text": appointment.status.text,
+    "classes": appointment.status.classes
   })}}
 
-  {% if params.status.key == params.allStatuses.CONFIRMED %}
-    <form action="{{ url('record_a_mammogram:check_in', kwargs={'id': params.id}) }}" <form method="post" novalidate>
+  {% if appointment.status.is_confirmed %}
+    <form action="{{ url('record_a_mammogram:check_in', kwargs={'id': appointment.id}) }}" <form method="post" novalidate>
     <p class="nhsuk-u-margin-top-2 nhsuk-u-margin-bottom-0">
       <button class="app-button--link">
         Check in
       </button>
     </p>
-    {{params.csrfInput}}
+    {{csrf_input}}
     </form>
   {% endif %}
 </div>

--- a/manage_breast_screening/templates/_components/participant-details/macro.jinja
+++ b/manage_breast_screening/templates/_components/participant-details/macro.jinja
@@ -1,3 +1,3 @@
-{% macro participantDetails(participant, lastKnownScreening, isMinimalParticipant = true, allowEdits = false) %}
+{% macro participant_details(participant, last_known_screening) %}
   {%- include '_components/participant-details/template.jinja' -%}
 {% endmacro %}

--- a/manage_breast_screening/templates/_components/participant-details/template.jinja
+++ b/manage_breast_screening/templates/_components/participant-details/template.jinja
@@ -1,27 +1,27 @@
 {% from 'components/summary-list/macro.jinja' import summaryList %}
 
 {% set dob %}
-  {{ participant.date_of_birth | formatDate }}<br>
-  <span class="nhsuk-hint">({{ participant.age() | formatAge }})</span>
+  {{ participant.date_of_birth }}<br>
+  <span class="nhsuk-hint">({{ participant.age }})</span>
 {% endset %}
 
-{% set ethnicGroup = participant.ethnic_group  %}
-{% set ethnicGroupCategory = participant.ethnic_group_category() %}
-{% set ethnicityDetailsLink %}
+{% set ethnic_group = participant.ethnic_group  %}
+{% set ethnic_group_category = participant.ethnic_group_category %}
+{% set ethnicity_details_link %}
   <a href="#" class="nhsuk-link">Enter ethnicity details</a>
 {% endset %}
 
-{% set ethnicityHtml %}
-  {% if ethnicGroup == "Prefer not to say" %}
-    {{ ethnicGroup }}
-  {% elif ethnicGroup %}
-    {{ ethnicGroupCategory }} ({{ ethnicGroup | replace('Any other', 'any other') }})
+{% set ethnicity_html %}
+  {% if ethnic_group == "Prefer not to say" %}
+    {{ ethnic_group }}
+  {% elif ethnic_group %}
+    {{ ethnic_group_category }} ({{ ethnic_group }})
   {% else %}
-    {{ ethnicityDetailsLink | safe }}
+    {{ ethnicity_details_link | safe }}
   {% endif %}
 {% endset %}
 
-{% set addressHtml %}
+{% set address_html %}
   {% if participant.address %}
     {% for line in participant.address.lines %}
       {{ line }}<br>
@@ -29,17 +29,18 @@
     {{ address.postcode }}
   {% endif %}
 {% endset %}
-{% set addressHtml = addressHtml | trim | default("Not provided") %}
+{% set address_html = address_html | trim | default("Not provided") %}
 
-{% set lastMammogramHtml %}
-  {% if lastKnownScreening %}
-    {{ lastKnownScreening.date | formatDate }} ({{ lastKnownScreening.date | formatRelativeDate | asHint }})
-    {% if lastKnownScreening.location %}
-      </br>{{ lastKnownScreening.location }}
-      {% if lastKnownScreening.type %}</br>{{ lastKnownScreening.type | sentenceCase }}{% endif %}
+{% set last_known_screening = appointment.last_known_screening %}
+{% set last_mammogram_html %}
+  {% if last_known_screening %}
+    {{ last_known_screening.date }} ({{ last_known_screening.relative_date | as_hint }})
+    {% if last_known_screening.location %}
+      </br>{{ last_known_screening.location }}
+      {% if last_known_screening.type %}</br>{{ last_known_screening.type }}{% endif %}
     {% endif %}
   {% else %}
-  {{ "Not known" | asHint }}
+  {{ "Not known" | as_hint }}
   {% endif %}
 {% endset %}
 
@@ -53,56 +54,9 @@
        "text": participant.full_name
      },
      "actions": {
-        "items": [
-          {
-            "href": "#",
-            "text": "Change",
-            "visuallyHiddenText": "date of birth"
-          } if allowEdits else []
-        ]
-      }
+       "items": [{}]
+     }
    },
-   {
-     "key": {
-       "text": "Gender"
-     },
-     "value": {
-       "text": "Female"
-     },
-     "actions": {
-        "items": [
-        ]
-     }
-   } if not isMinimalParticipant,
-   {
-     "key": {
-       "text": "NHS number"
-     },
-     "value": {
-       "text": participant.medicalInformation.nhsNumber | formatNhsNumber
-     },
-     "actions": {
-        "items": [
-        ]
-     }
-   } if not isMinimalParticipant,
-   {
-     "key": {
-       "text": "SX number"
-     },
-     "value": {
-       "text": participant.sxNumber
-     },
-     "actions": {
-        "items": [
-          {
-            "href": "#",
-            "text": "Change",
-            "visuallyHiddenText": "SX number"
-          } if allowEdits
-        ]
-      }
-   } if not isMinimalParticipant,
    {
      "key": {
        "text": "Date of birth"
@@ -111,8 +65,7 @@
        "html": dob
      },
      "actions": {
-        "items": [
-        ]
+       "items": [{}]
      }
    },
    {
@@ -120,75 +73,29 @@
        "text": "Ethnicity"
      },
      "value": {
-       "html": ethnicityHtml | safe
+       "html": ethnicity_html | safe
      },
      "actions": {
-        "items": [
-          {
-            "href": "#",
-            "text": "Change",
-            "visuallyHiddenText": "address"
-          } if false else []
-        ]
-      }
+      "items": [{}]
+     }
    },
    {
      "key": {
        "text": "Address"
      },
      "value": {
-       "html": addressHtml
+       "html": address_html
      },
      "actions": {
-        "items": [
-          {
-            "href": "#",
-            "text": "Change",
-            "visuallyHiddenText": "address"
-          } if allowEdits else []
-        ]
-      }
+       "items": [{}]
+     }
    },
-   {
-     "key": {
-       "text": "Phone"
-     },
-     "value": {
-       "text": participant.phone | formatPhoneNumber
-     },
-     "actions": {
-        "items": [
-          {
-            "href": "#",
-            "text": "Change",
-            "visuallyHiddenText": "phone"
-          } if allowEdits
-        ]
-      }
-   } if not isMinimalParticipant,
-   {
-     "key": {
-       "text": "Email"
-     },
-     "value": {
-       "text": participant.demographicInformation.email
-     },
-     "actions": {
-        "items": [
-          {
-            "href": "#",
-            "text": "Change",
-            "visuallyHiddenText": "email"
-          } if allowEdits
-        ]
-      }
-   } if not isMinimalParticipant,
    {
      "key": {
        "text": "Last known mammogram"
      },
      "value": {
-       "html": lastMammogramHtml
+       "html": last_mammogram_html
      },
      "actions": {
         "items": [
@@ -205,17 +112,11 @@
        "text": "Risk level"
      },
      "value": {
-       "html": participant.risk_level | sentenceCase
+       "html": participant.risk_level
      },
      "actions": {
-        "items": [
-          {
-            "href": "#",
-            "text": "View or update screening history",
-            "visuallyHiddenText": "email"
-          } if allowEdits else []
-        ]
-      }
+       "items": [{}]
+     }
    }
   ]
 }) }}

--- a/manage_breast_screening/templates/_components/secondary-navigation/macro.jinja
+++ b/manage_breast_screening/templates/_components/secondary-navigation/macro.jinja
@@ -1,3 +1,3 @@
-{% macro app_secondary_navigation(visually_hidden_title, items) %}
+{% macro appSecondaryNavigation(params) %}
   {%- include "_components/secondary-navigation/template.jinja" -%}
 {% endmacro %}

--- a/manage_breast_screening/templates/_components/secondary-navigation/macro.jinja
+++ b/manage_breast_screening/templates/_components/secondary-navigation/macro.jinja
@@ -1,3 +1,3 @@
-{% macro appSecondaryNavigation(params) %}
+{% macro app_secondary_navigation(visually_hidden_title, items) %}
   {%- include "_components/secondary-navigation/template.jinja" -%}
 {% endmacro %}

--- a/manage_breast_screening/templates/clinics/index.html
+++ b/manage_breast_screening/templates/clinics/index.html
@@ -71,8 +71,8 @@ All clinics this week
           ({{ clinic.session_type() | capitalize }})
         </a>
       </td>
-      <td>{{ clinic.starts_at | formatDate | noWrap }}<br>
-        {{clinic.time_range() | formatTimeRange | asHint }}
+      <td>{{ clinic.starts_at | format_date | noWrap }}<br>
+        {{clinic.time_range() | format_time_range | as_hint }}
       </td>
       <td>
         {{ clinic.get_type_display() | capitalize }}

--- a/manage_breast_screening/templates/clinics/index.html
+++ b/manage_breast_screening/templates/clinics/index.html
@@ -4,44 +4,32 @@
 {% from '_components/count/macro.jinja' import appCount %}
 {% from '_components/secondary-navigation/macro.jinja' import appSecondaryNavigation %}
 
-{% set pageHeading %}
-{% if filter == 'today' %}
-Today’s clinics
-{% elif filter == 'upcoming' %}
-Upcoming clinics
-{% elif filter == 'completed' %}
-Completed clinics this week
-{% else %}
-All clinics this week
-{% endif %}
-{% endset %}
-
 {% block content %}
-<h1>{{pageHeading}}</h1>
+<h1>{{ presenter.heading }}</h1>
 
 {% set ns = namespace() %}
 {% set ns.secondaryNavItems = [] %}
 
 {% for item in [
-{ "id": 'today', "label": 'Today' },
-{ "id": 'upcoming', "label": 'Upcoming' },
-{ "id": 'completed', "label": 'Completed' },
-{ "id": 'all', "label": 'All' }
+  { "id": 'today', "label": 'Today' },
+  { "id": 'upcoming', "label": 'Upcoming' },
+  { "id": 'completed', "label": 'Completed' },
+  { "id": 'all', "label": 'All' }
 ] %}
 {% set href %}/clinics/{{ item.id }}{% endset %}
 {% set ns.secondaryNavItems = ns.secondaryNavItems + [{
-"text": (item.label + " " + appCount(filteredClinicCounts[item.id])) | safe,
-"href": href | trim,
-"current": true if item.id == filter
+  "text": (item.label + " " + appCount(presenter.counts_by_filter[item.id])) | safe,
+  "href": href | trim,
+  "current": true if item.id == presenter.filter
 }] %}
 {% endfor %}
 
 {{ appSecondaryNavigation({
-"visuallyHiddenTitle": "Secondary menu",
-"items": ns.secondaryNavItems
+  "visuallyHiddenTitle": "Secondary menu",
+  "items": ns.secondaryNavItems
 }) }}
 
-{% if filteredClinics | length == 0 %}
+{% if presenter.clinics | length == 0 %}
 <p>No clinics found.</p>
 {% else %}
 <table class="nhsuk-table">
@@ -55,39 +43,31 @@ All clinics this week
     </tr>
   </thead>
   <tbody class="nhsuk-table__body">
-    {% for clinic in filteredClinics | sort(false, false, 'starts_at') %}
-    {% set location = clinic.setting %}
-    {% set events = clinic.slots %}
+    {% for clinic in presenter.clinics %}
     <tr>
       <td>
         <a href="/clinics/{{ clinic.id }}" class="nhsuk-link">
-          {#- FIXME-#}
-          {% if location.type == 'mobile_unit' %}
-          {{ location.name }} at {{ clinic.siteName }}
-          {% else %}
-          {{ location.name }}
-          {% endif %}
+          {{ clinic.location_name }}
           <br>
-          ({{ clinic.session_type() | capitalize }})
+          ({{ clinic.session_type }})
         </a>
       </td>
-      <td>{{ clinic.starts_at | format_date | noWrap }}<br>
-        {{clinic.time_range() | format_time_range | as_hint }}
+      <td>{{ clinic.starts_at | no_wrap }}<br>
+        {{clinic.time_range | as_hint }}
       </td>
       <td>
-        {{ clinic.get_type_display() | capitalize }}
+        {{ clinic.type }}
         <br>
-        <span class="app-text-grey">{{ clinic.get_risk_type_display() | capitalize }}</span>
-
+        <span class="app-text-grey">{{ clinic.risk_type }}</span>
       </td>
 
       <td class="nhsuk-table__cell--numeric">
-        {{ events | length }}
+        {{ clinic.number_of_slots }}
       </td>
-      <td class="nhsuk-table__cell--numeric">
+      <td>
         {{ tag({
-        "html": clinic.get_state_display() | noWrap,
-        "classes": "nhsuk-tag--" + STATUS_COLORS[clinic.state]
+          "html": clinic.state.text | no_wrap,
+          "classes": clinic.state.classes
         })}}
       </td>
     </tr>

--- a/manage_breast_screening/templates/record_a_mammogram/appointment_cannot_go_ahead.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/appointment_cannot_go_ahead.jinja
@@ -3,9 +3,6 @@
 {% from "input/macro.jinja" import input %}
 {% from "radios/macro.jinja" import radios %}
 
-{% set title = "Appointment cannot go ahead" %}
-{% set caption = participant.full_name %}
-
 {% block form %}
 {% macro conditionalCheckboxInput(params) %}
   {% set details_field_name = params.field_name + "_details" %}

--- a/manage_breast_screening/templates/record_a_mammogram/ask_for_medical_information.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/ask_for_medical_information.jinja
@@ -1,4 +1,2 @@
 {% extends "wizard_step.jinja" %}
 
-{% set title = "Medical information" %}
-{% set decision_legend = "Has the participant shared any relevant medical information?" %}

--- a/manage_breast_screening/templates/record_a_mammogram/awaiting_images.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/awaiting_images.jinja
@@ -1,3 +1,1 @@
 {% extends "wizard_step.jinja" %}
-
-{% set title = "Awaiting images" %}

--- a/manage_breast_screening/templates/record_a_mammogram/record_medical_information.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/record_medical_information.jinja
@@ -1,4 +1,1 @@
 {% extends "wizard_step.jinja" %}
-
-{% set title = "Record medical information" %}
-{% set decision_legend = "Can imaging go ahead?" %}

--- a/manage_breast_screening/templates/record_a_mammogram/start_screening.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/start_screening.jinja
@@ -1,15 +1,10 @@
 {% extends "wizard_step.jinja" %}
 {% from 'card/macro.jinja' import card %}
 {% from 'warning-callout/macro.jinja' import warningCallout %}
-{% from '_components/appointment-status/macro.jinja' import appointmentStatus %}
-{% from '_components/appointment-header/macro.jinja' import appointmentHeader %}
-{% from '_components/participant-details/macro.jinja' import participantDetails %}
+{% from '_components/appointment-status/macro.jinja' import appointment_status %}
+{% from '_components/appointment-header/macro.jinja' import appointment_header %}
+{% from '_components/participant-details/macro.jinja' import participant_details %}
 {% from '_components/secondary-navigation/macro.jinja' import appSecondaryNavigation %}
-
-{% set caption = clinic_slot.clinic.get_type_display() | capitalize ~ " appointment" %}
-{% set title = participant.first_name ~ " " ~ participant.last_name %}
-{% set decision_legend = "Can the appointment go ahead?" %}
-{% set decision_hint = "Before you proceed, check the participant’s identity and confirm that their last mammogram was more than 6 months ago." %}
 
 {% block heading %}
   <div class="app-header-with-status">
@@ -21,18 +16,15 @@
     </h1>
 
     <div class="app-header-with-status__status-tag">
-      {{ appointmentStatus({
-        "clinicId": clinic.id,
-        "id": appointment.id,
-        "status": status,
-        "allStatuses": Status,
-        "csrfInput": csrf_input
-      })}}
+      {{ appointment_status(
+        appointment=appointment,
+        csrf_input=csrf_input
+      )}}
     </div>
 {% endblock %}
 
 {% block stepContent %}
-  {{ appointmentHeader(appointment) }}
+  {{ appointment_header(appointment) }}
 
   {% if secondary_nav_items %}
     {{ appSecondaryNavigation({
@@ -41,7 +33,7 @@
     }) }}
   {% endif %}
 
-  {% set specialAppointmentHtml %}
+  {% set special_appointment_html %}
     {% if participant.extra_needs | length > 1 %}
       <ul>
         {% for need in participant.extra_needs %}
@@ -57,13 +49,13 @@
   {% if participant.extra_needs %}
     {{ warningCallout({
       "heading": "Special appointment",
-      "HTML": specialAppointmentHtml
+      "HTML": special_appointment_html
     }) }}
   {% endif %}
 
   {{ card({
     "headingHtml": " ",
     "headingLevel": "2",
-    "descriptionHtml": participantDetails(participant=participant, lastKnownScreening=last_known_screening)
+    "descriptionHtml": participant_details(participant=appointment.participant, last_known_screening=appointment.last_known_screening)
   }) }}
 {% endblock %}

--- a/manage_breast_screening/utils/string_formatting.py
+++ b/manage_breast_screening/utils/string_formatting.py
@@ -1,0 +1,45 @@
+import re
+
+
+def sentence_case(value):
+    """
+    Capitalise the first letter of a sentence.
+
+    >>> sentence_case('a quick brown fox jumps over the lazy dog')
+    'A quick brown fox jumps over the lazy dog'
+
+    Unlike the built in `capitalize` filter, this will preserve
+    capital letters already in the string:
+
+    >>> sentence_case('not in PACS')
+    'Not in PACS'
+    """
+    if not value:
+        return ""
+
+    return value[0].upper() + value[1:]
+
+
+def format_nhs_number(value):
+    """
+    Format an NHS number with spaces
+
+    >>> format_nhs_number('9998887777')
+    '999 888 7777'
+    """
+    if not value:
+        return ""
+
+    digits = re.sub(r"\s", "", value)
+
+    return f"{digits[:3]} {digits[3:6]} {digits[6:]}"
+
+
+def format_age(value: int) -> str:
+    """
+    Format an age in years as a string
+
+    >>> format_age(64)
+    '64 years old'
+    """
+    return f"{value} years old"


### PR DESCRIPTION
This PR introduces [presenters](https://thoughtbot.com/blog/using-the-presenter-pattern-in-ruby-on-rails):

> The presenter pattern, sometimes called the “ViewModel” pattern, is essentially an intermediary between the model and the view. While the model handles core business logic and data, the presenter’s job is to prepare the model’s data specifically for display.

This was suggested by @colinrotherham in a previous PR and I thought it was a good idea to do now as the templates are getting quite complex.

So the goal of this PR is to:
- simplify the template logic
- remove the need for so many custom template filters
- test more of the code that formats data for display

As a proof of concept, I've migrated the start screening template to this approach in the second commit. If we're happy with the general approach, I can do the same thing for the rest of them.

I've also addressed a few other things as part of rewriting the template:
- use snake case where possible
- remove some conditionals from the prototype which we aren't using yet

## Things to review
- The presenter classes are value objects with lots of individual properties. An alternative way of doing it would be to have a method that returns/updates a whole context object. Not sure which would be cleaner here.
- The presenters I've implemented are designed to work with specific models rather than being coupled to a particular page.
- I was initially thinking of having methods that would output params exactly as they are needed by components such as the summary list. I decided against it, because there are cases where html is passed into the components, and it seems safer to handle this in the template.
- I've introduced some new unit tests that use mocks, rather than instantiating all the models. I'm kind of aiming for a similar style to how we would test in rails/rspec
- I've snake cased most of the custom macros, but an exception is `secondary-navigation`. This is because this came from another service, and I'd rather not change it just to meet our style. I've also raised a ticket to look at updating this https://nhsd-jira.digital.nhs.uk/browse/DTOSS-9107