### PR TITLE
Add system test helper for validation errors

### DIFF
--- a/manage_breast_screening/config/system_test_setup.py
+++ b/manage_breast_screening/config/system_test_setup.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from playwright.sync_api import sync_playwright
+from playwright.sync_api import sync_playwright, expect
 
 
 @pytest.mark.system
@@ -26,3 +26,12 @@ class SystemTestCase(StaticLiveServerTestCase):
 
     def tearDown(self):
         self.page.close()
+
+    def expect_validation_error(self, id: str, fieldset_legend: str, error_text: str):
+        summary_box = self.page.locator(".nhsuk-error-summary")
+        error_link = summary_box.locator(f"a[href='#{id}']")
+        expect(error_link).to_have_text(error_text)
+
+        fieldset = self.page.locator('fieldset').filter(has_text=fieldset_legend)
+        error_span = fieldset.locator("span").filter(has_text=error_text)
+        expect(error_span).to_have_id(id)

--- a/manage_breast_screening/record_a_mammogram/tests/system/test_user_submits_cannot_go_ahead_form.py
+++ b/manage_breast_screening/record_a_mammogram/tests/system/test_user_submits_cannot_go_ahead_form.py
@@ -43,9 +43,16 @@ class TestUserSubmitsCannotGoAheadForm(SystemTestCase):
         self.page.get_by_role("button", name="Continue").click()
 
     def then_i_should_see_validation_errors(self):
-        expect(
-            self.page.locator("#stopped_reasons-error")
-        ).to_have_text(re.compile("A reason for why this appointment cannot continue must be provided"))
+        self.expect_validation_error(
+            id="stopped_reasons-error",
+            fieldset_legend="Why has this appointment been stopped?",
+            error_text="A reason for why this appointment cannot continue must be provided",
+        )
+        self.expect_validation_error(
+            id="decision-error",
+            fieldset_legend="Does the appointment need to be rescheduled?",
+            error_text="Select whether the participant needs to be invited for another appointment"
+        )
 
     def when_i_select_a_reason_for_the_appointment_being_stopped(self):
         self.page.get_by_label("Failed identity check").check()
@@ -58,9 +65,11 @@ class TestUserSubmitsCannotGoAheadForm(SystemTestCase):
         expect(self.page.get_by_label("Yes, add participant to reinvite list")).to_be_checked()
 
     def then_i_see_an_error_for_other_details(self):
-        expect(
-            self.page.locator("#other_details-error")
-        ).to_have_text(re.compile("Explain why this appointment cannot proceed"))
+        self.expect_validation_error(
+            id="other_details-error",
+            fieldset_legend="Why has this appointment been stopped?",
+            error_text="Explain why this appointment cannot proceed",
+        )
 
     def when_i_fill_in_other_details(self):
         self.page.locator("#other_details").fill("Explain other choice")


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->
This helper provides a convenient way to test form validations with
slightly more detail than simply asserting the presence of the error
on the page.

The helper:

- Asserts that the error link appears in the summary box
- Locates the error link by the expected id
- Locates the error within the expected fieldset
- Asserts that the error is a span with the expected id



## Review notes
I also attempted to write a test that checks the correct error is focused after clicking the link in the error summary, as outlined by Colin [here](https://github.com/NHSDigital/manage-breast-screening/pull/30#discussion_r2087051187).

This proved to be challenging, however. It is possible to retrieve the `document.activeElement` via playwright-python, using something like:

```python
        summary_box.get_by_text(error_text).click()
        active_element_info = self.page.evaluate("""() => {
            const activeElement = document.activeElement;
            return {
                hash: activeElement.hash,
                text: activeElement.textContent,
            }
        }""")
        error_hash_identifier = active_element_info["hash"].replace("#", "")
```

The issue is that the return value of document.activeElement isn't consistent on this form:

<img width="242" alt="Screenshot 2025-05-20 at 14 22 12" src="https://github.com/user-attachments/assets/719b6368-a3db-4c52-89de-a322b93ab475" />

The former is what you get after clicking the validation error for the reinvite radio buttons. The latter is after clicking the validation error for the Other details input field (a conditional field rendered under a checkbox).

@colinrotherham this might be because of how we built the form, although it's not obvious to me what the issue is there. Is it possible this is a bug/unexpected behaviour in nhsuk-frontend?

As it stands, I opted for a helper that:
- Checks the error is in the summary box
- Checks that it's also rendered in approximately the right part of the form (via fieldset legend)
- Checks that the id / URL hash is the same for both errors

<!-- Why is this change required? What problem does it solve? -->
