### PR TITLE
Additional tests for the cannot go ahead page

### DIFF
--- a/manage_breast_screening/record_a_mammogram/tests/system/test_user_submits_cannot_go_ahead_form.py
+++ b/manage_breast_screening/record_a_mammogram/tests/system/test_user_submits_cannot_go_ahead_form.py
@@ -82,3 +82,8 @@ class TestUserSubmitsCannotGoAheadForm(SystemTestCase):
     def and_the_appointment_is_updated(self):
         self.appointment.refresh_from_db()
         self.assertEqual(self.appointment.status, Appointment.Status.ATTENDED_NOT_SCREENED)
+        self.assertEqual(self.appointment.reinvite, True)
+        self.assertEqual(self.appointment.stopped_reasons, {
+            "stopped_reasons": ["failed_identity_check", "other"],
+            "other_details": "Explain other choice"
+        })

--- a/manage_breast_screening/record_a_mammogram/tests/test_forms.py
+++ b/manage_breast_screening/record_a_mammogram/tests/test_forms.py
@@ -1,9 +1,37 @@
 from pytest_django.asserts import assertFormError
+import pytest
 
-from ..forms import ScreeningAppointmentForm
+from manage_breast_screening.clinics.tests.factories import AppointmentFactory
+from ..forms import AppointmentCannotGoAheadForm, ScreeningAppointmentForm
 
 
 class TestScreeningAppointmentForm:
     def test_decision_cannot_be_left_blank(self):
         form = ScreeningAppointmentForm({})
         assertFormError(form, "decision", ["This field is required."])
+
+@pytest.mark.django_db
+class TestAppointmentCannotGoAheadForm:
+    def test_reinvite_reflects_form_data(self):
+        appointment = AppointmentFactory()
+        form_data = {
+            "stopped_reasons": ["failed_identity_check"],
+            "decision": "True",
+        }
+        form = AppointmentCannotGoAheadForm(form_data, instance=appointment)
+        form.is_valid()
+        form.save()
+        appointment.refresh_from_db()
+        assert appointment.reinvite is True
+
+        form_data = {
+            "stopped_reasons": ["failed_identity_check"],
+            "decision": "False",
+        }
+        form = AppointmentCannotGoAheadForm(form_data, instance=appointment)
+        form.is_valid()
+        form.save()
+        appointment.refresh_from_db()
+        assert appointment.reinvite is False
+
+

--- a/manage_breast_screening/record_a_mammogram/tests/test_forms.py
+++ b/manage_breast_screening/record_a_mammogram/tests/test_forms.py
@@ -12,26 +12,17 @@ class TestScreeningAppointmentForm:
 
 @pytest.mark.django_db
 class TestAppointmentCannotGoAheadForm:
-    def test_reinvite_reflects_form_data(self):
+    @pytest.mark.parametrize("decision,reinvite_value", [("True", True), ("False", False)])
+    def test_reinvite_reflects_form_data(self, decision, reinvite_value):
         appointment = AppointmentFactory()
+        assert appointment.reinvite == False
+
         form_data = {
             "stopped_reasons": ["failed_identity_check"],
-            "decision": "True",
+            "decision": decision,
         }
         form = AppointmentCannotGoAheadForm(form_data, instance=appointment)
         form.is_valid()
         form.save()
         appointment.refresh_from_db()
-        assert appointment.reinvite is True
-
-        form_data = {
-            "stopped_reasons": ["failed_identity_check"],
-            "decision": "False",
-        }
-        form = AppointmentCannotGoAheadForm(form_data, instance=appointment)
-        form.is_valid()
-        form.save()
-        appointment.refresh_from_db()
-        assert appointment.reinvite is False
-
-
+        assert appointment.reinvite == reinvite_value


### PR DESCRIPTION
## Description
- Add a few more assertions to the system test for this page that check database state.
- Add a form test that checks the boolean value for reinvite is persisted correctly depending on the form data.

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-8998

## Review notes
Adding a load of database checks to system tests isn't really the done thing as they're supposed to be written as a set of user interactions with the system. I think a handful of basic checks are fine, but more thorough testing of database state (and validations for that matter) should probably be done in the view/form tests.

The form test I've added is an example of covering behaviour not adequately tested by the system test.


