### PR TITLE
Correctly link errors to the matching form field

### DIFF
--- a/manage_breast_screening/record_a_mammogram/forms.py
+++ b/manage_breast_screening/record_a_mammogram/forms.py
@@ -68,6 +68,12 @@ class AppointmentCannotGoAheadForm(forms.Form):
         for field_name, _ in self.STOPPED_REASON_CHOICES:
             self.fields[f"{field_name}_details"] = forms.CharField(required=False)
 
+        # Ensure that the field order matches the order we want to render in
+        details_fields = [
+            f"{field_name}_details" for field_name, _ in self.STOPPED_REASON_CHOICES
+        ]
+        self.order_fields(["stopped_reasons"] + details_fields + ["decision"])
+
     stopped_reasons = forms.MultipleChoiceField(
         choices=STOPPED_REASON_CHOICES,
         required=True,

--- a/manage_breast_screening/record_a_mammogram/tests/system/test_recording_a_mammogram.py
+++ b/manage_breast_screening/record_a_mammogram/tests/system/test_recording_a_mammogram.py
@@ -20,6 +20,9 @@ class TestRecordingAMammogram(SystemTestCase):
         self.appointment = AppointmentFactory(screening_episode=self.screening_episode)
 
     def test_recording_a_mammogram_without_capturing_medical_information(self):
+        """
+        I can record a mammogram without entering any relevant medical information.
+        """
         self.given_i_am_on_the_start_screening_page()
         self.then_i_should_see_the_demographic_banner()
         self.and_i_should_see_the_participant_details()
@@ -28,8 +31,29 @@ class TestRecordingAMammogram(SystemTestCase):
         self.then_i_should_be_on_the_medical_information_page()
         self.and_i_should_be_prompted_to_ask_about_relevant_medical_information()
 
-        self.when_the_participant_shares_no_relevant_medical_information()
+        self.when_i_mark_that_the_participant_shared_no_medical_information()
         self.then_the_screen_should_show_that_it_is_awaiting_images_from_the_PACS()
+
+    def test_filling_out_forms_incorrectly(self):
+        """
+        At each step in the flow, when I fill out the forms incorrectly,
+        then I should see the errors so I can fix them.
+        """
+        self.given_i_am_on_the_start_screening_page()
+        self.when_i_submit_the_form()
+        self.then_i_am_prompted_to_answer_can_the_screening_go_ahead()
+
+        self.when_i_check_the_participants_identity_and_confirm_the_last_mammogram_date()
+        self.then_i_should_be_on_the_medical_information_page()
+
+        self.when_i_submit_the_form()
+        self.then_i_am_prompted_to_answer_has_the_participant_shared_medical_info()
+
+        self.when_i_mark_that_the_participant_shared_medical_information()
+        self.then_i_should_be_on_the_record_medical_information_page()
+
+        self.when_i_submit_the_form()
+        self.then_i_am_prompted_to_confirm_whether_imaging_can_go_ahead()
 
     def given_i_am_on_the_start_screening_page(self):
         self.page.goto(
@@ -54,9 +78,19 @@ class TestRecordingAMammogram(SystemTestCase):
         self.page.get_by_label("Yes, go to medical information").check()
         self.page.get_by_role("button", name="Continue").click()
 
+    def when_i_submit_the_form(self):
+        self.page.get_by_role("button", name="Continue").click()
+
     def then_i_should_be_on_the_medical_information_page(self):
         path = reverse(
             "record_a_mammogram:ask_for_medical_information",
+            kwargs={"id": self.appointment.pk},
+        )
+        expect(self.page).to_have_url(re.compile(path))
+
+    def then_i_should_be_on_the_record_medical_information_page(self):
+        path = reverse(
+            "record_a_mammogram:record_medical_information",
             kwargs={"id": self.appointment.pk},
         )
         expect(self.page).to_have_url(re.compile(path))
@@ -68,8 +102,12 @@ class TestRecordingAMammogram(SystemTestCase):
             )
         ).to_be_visible()
 
-    def when_the_participant_shares_no_relevant_medical_information(self):
+    def when_i_mark_that_the_participant_shared_no_medical_information(self):
         self.page.get_by_label("No - proceed to imaging").check()
+        self.page.get_by_role("button", name="Continue").click()
+
+    def when_i_mark_that_the_participant_shared_medical_information(self):
+        self.page.get_by_label("Yes").check()
         self.page.get_by_role("button", name="Continue").click()
 
     def then_the_screen_should_show_that_it_is_awaiting_images_from_the_PACS(self):
@@ -78,3 +116,24 @@ class TestRecordingAMammogram(SystemTestCase):
             kwargs={"id": self.appointment.pk},
         )
         expect(self.page).to_have_url(re.compile(path))
+
+    def then_i_am_prompted_to_answer_can_the_screening_go_ahead(self):
+        self.expect_validation_error(
+            error_text="This field is required.",
+            fieldset_legend="Can the appointment go ahead?",
+            field_label="Yes, go to medical information",
+        )
+
+    def then_i_am_prompted_to_answer_has_the_participant_shared_medical_info(self):
+        self.expect_validation_error(
+            error_text="This field is required.",
+            fieldset_legend="Has the participant shared any relevant medical information?",
+            field_label="Yes",
+        )
+
+    def then_i_am_prompted_to_confirm_whether_imaging_can_go_ahead(self):
+        self.expect_validation_error(
+            error_text="This field is required.",
+            fieldset_legend="Can imaging go ahead?",
+            field_label="Yes, mark incomplete sections as ‘none’ or ‘no’",
+        )

--- a/manage_breast_screening/templates/record_a_mammogram/appointment_cannot_go_ahead.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/appointment_cannot_go_ahead.jinja
@@ -6,15 +6,17 @@
 {% block form %}
 {% macro conditionalCheckboxInput(params) %}
   {% set details_field_name = params.field_name + "_details" %}
+  {% set details_field_id = params.details_field.auto_id %}
+  {% set details_field_value = params.details_field.value() %}
   {% set input_params = {
     "label": {
       "text": "Provide details"
     },
-    "id": details_field_name,
+    "id": details_field_id,
     "name": details_field_name,
-    "value": params.details_value
+    "value": details_field_value
   } %}
-  {% if form[details_field_name].errors %}
+  {% if params.details_field.errors %}
     {% set error_params = {
       "errorMessage": {
         "text": form[details_field_name].errors | first
@@ -31,20 +33,21 @@
 {% for field_name, label in form.stopped_reasons.field.choices %}
     {% do checkboxItems.append({
       "text": label,
+      "id": form.stopped_reasons.auto_id if loop.first,
       "value": field_name,
       "checked": field_name in (form.stopped_reasons.value() or []),
       "conditional": {
         "html": conditionalCheckboxInput({
           "field_name": field_name,
-          "details_value": form[field_name + "_details"].value()
+          "details_field": form[field_name + "_details"],
         })
       }
     }) %}
 {% endfor %}
 
 {% set checkbox_params = {
-  "idPrefix": "stopped_reasons",
-  "name": "stopped_reasons",
+  "idPrefix": form.stopped_reasons.auto_id,
+  "name": form.stopped_reasons.html_name,
   "fieldset": {
     "legend": {
       "text": "Why has this appointment been stopped?",

--- a/manage_breast_screening/templates/wizard_step.jinja
+++ b/manage_breast_screening/templates/wizard_step.jinja
@@ -18,7 +18,7 @@
       {% set ns = namespace(errors=[]) %}
 
       {% for field, messages in form.errors | items %}
-        {% set ns.errors = ns.errors + [{"text": ",".join(messages), "href": "#" ~ field ~ "-error"}] %}
+        {% set ns.errors = ns.errors + [{"text": ",".join(messages), "href": "#" ~ messages.field_id}] %}
       {% endfor %}
 
       {{ errorSummary({
@@ -56,6 +56,7 @@
 
             {{ radios({
               "name": form.decision.html_name,
+              "idPrefix": form.decision.auto_id,
               "fieldset": {
                 "legend": {
                   "text": decision_legend,
@@ -69,6 +70,7 @@
               } if decision_hint,
               "items": [
                 {
+                  "id": form.decision.auto_id,
                   "value": form.decision.field.choices[0][0],
                   "text": form.decision[0].choice_label,
                   "checked": form.decision.value() == form.decision.field.choices[0][0]

--- a/manage_breast_screening/templates/wizard_step.jinja
+++ b/manage_breast_screening/templates/wizard_step.jinja
@@ -17,8 +17,11 @@
     {% if form.errors %}
       {% set ns = namespace(errors=[]) %}
 
-      {% for field, messages in form.errors | items %}
-        {% set ns.errors = ns.errors + [{"text": ",".join(messages), "href": "#" ~ messages.field_id}] %}
+      {% for field in form %}
+        {% set ns.errors = ns.errors + [{"text": ",".join(field.errors), "href": "#" ~ field.auto_id}] %}
+      {% endfor %}
+      {% for error_list in form.non_field_errors() %}
+        {% set ns.errors = ns.errors + [{"text": ",".join(error_list)}] %}
       {% endfor %}
 
       {{ errorSummary({


### PR DESCRIPTION
We have a pattern for presenting errors at the top of the page. When you click on the error, the relevant field should be focused (rather than the previous behaviour of just navigating to the error)

In the case of checkboxes and radios, we need to link to the first option. Since the ErrorList object we are iterating over doesn't know whether the field contains checkboxes/radios, the easiest way to do this is to always link to [`ErrorList.field_id`](https://docs.djangoproject.com/en/5.2/ref/forms/api/#django.forms.ErrorList.field_id), which is the same Django-generated ID as [`field.auto_id`](https://docs.djangoproject.com/en/5.2/ref/forms/api/#django.forms.Form.auto_id), without a suffix like "-1", "-2" etc.

To make this all work, we have to explicitly set the `id` param of the first checkbox/radio to the unsuffixed `field.auto_id`, while letting the component generate the rest of the IDs with suffixes. If https://github.com/nhsuk/nhsuk-frontend/pull/1112 is merged, then we will no longer need to specify this, we can just provide the `idPrefix`.

Example screenshot (note: the rest of this page is not implemented yet)
![Screenshot showing a radio field with the first option with a yellow focus outline, after clicking on an error link](https://github.com/user-attachments/assets/2ba03318-bb6d-4fb0-b769-1c7899e925cb)

While fixing this, I also noticed that errors were displayed in a strange order in the error summary, with fields that appear lower down the page being mentioned before fields that appear higher up the page. I've changed this to show them in field order.
![Screenshot showing the error summary with two errors](https://github.com/user-attachments/assets/c6314e44-adb0-44e1-b9d8-9431477218c5)

