### PR TITLE
(Refactor) add some helper macros for form fields

### DIFF
--- a/manage_breast_screening/templates/forms/form_helpers.jinja
+++ b/manage_breast_screening/templates/forms/form_helpers.jinja
@@ -1,0 +1,54 @@
+{% from 'radios/macro.jinja' import radios %}
+{% from "checkboxes/macro.jinja" import checkboxes %}
+{% from 'error-summary/macro.jinja' import errorSummary %}
+
+{% macro form_error_summary(form, title="There is a problem") %}
+    {% if form.errors %}
+      {% set ns = namespace(errors=[]) %}
+
+      {% for field in form %}
+        {% set ns.errors = ns.errors + [{"text": ",".join(field.errors), "href": "#" ~ field.auto_id}] %}
+      {% endfor %}
+      {% for error_list in form.non_field_errors() %}
+        {% set ns.errors = ns.errors + [{"text": ",".join(error_list)}] %}
+      {% endfor %}
+
+      {{ errorSummary({
+        "titleText": title,
+        "errorList": ns.errors
+      }) }}
+    {% endif %}
+{% endmacro %}
+
+{% macro choice_field(field, fieldset=None, hint=None, component=radios) %}
+  {% if field.errors %}
+    {% set error_message = {"text": field.errors | first} %}
+  {% endif %}
+  {% set ns = namespace(items=[]) %}
+  {% for choice in field.field.choices %}
+    {% set ns.items = ns.items + [{
+      "id": field.auto_id if loop.first,
+      "value": choice[0],
+      "text": choice[1],
+      "checked": field.value() == choice[0]
+    }] %}
+  {% endfor %}
+  {{ component({
+    "name": field.html_name,
+    "idPrefix": field.auto_id,
+    "fieldset": fieldset if fieldset,
+    "errorMessage": error_message,
+    "hint": {
+      "html": hint|e
+    } if hint,
+    "items": ns.items
+  }) }}
+{% endmacro %}
+
+{% macro choice_field_to_radios(field, fieldset=None, hint=None) %}
+  {{ choice_field(field=field, fieldset=fieldset, hint=hint, component=radios) }}
+{% endmacro %}
+
+{% macro choice_field_to_checkboxes(field, fieldset=None, hint=None) %}
+  {{ choice_field(field=field, fieldset=fieldset, hint=hint, component=checkboxes) }}
+{% endmacro %}

--- a/manage_breast_screening/templates/wizard_step.jinja
+++ b/manage_breast_screening/templates/wizard_step.jinja
@@ -3,7 +3,7 @@
 {% from 'button/macro.jinja' import button %}
 {% from 'fieldset/macro.jinja' import fieldset %}
 {% from 'back-link/macro.jinja' import backLink %}
-{% from 'error-summary/macro.jinja' import errorSummary %}
+{% from 'forms/form_helpers.jinja' import choice_field_to_radios, form_error_summary %}
 
 {% block beforeContent %}
 {# Using javascript temporarily - this should be replaced with proper URLs #}
@@ -14,21 +14,7 @@
 {% endblock beforeContent %}
 
 {% block messages %}
-    {% if form.errors %}
-      {% set ns = namespace(errors=[]) %}
-
-      {% for field in form %}
-        {% set ns.errors = ns.errors + [{"text": ",".join(field.errors), "href": "#" ~ field.auto_id}] %}
-      {% endfor %}
-      {% for error_list in form.non_field_errors() %}
-        {% set ns.errors = ns.errors + [{"text": ",".join(error_list)}] %}
-      {% endfor %}
-
-      {{ errorSummary({
-        "titleText": "There is a problem",
-        "errorList": ns.errors
-      }) }}
-    {% endif %}
+  {{ form_error_summary(form) }}
 {% endblock %}
 
 {% block pageContent %}
@@ -53,38 +39,17 @@
           {% block form %}{% endblock form %}
 
           {% if form.decision %}
-            {% if form.decision.errors %}
-              {% set errorMessage = {"text": form.decision.errors | first} %}
-            {% endif %}
-
-            {{ radios({
-              "name": form.decision.html_name,
-              "idPrefix": form.decision.auto_id,
-              "fieldset": {
+            {{ choice_field_to_radios(
+              field=form.decision,
+              fieldset={
                 "legend": {
                   "text": decision_legend,
                   "classes": "nhsuk-fieldset__legend--m",
                   "isPageHeading": false
                 }
               },
-              "errorMessage": errorMessage,
-              "hint": {
-                "html": decision_hint|e
-              } if decision_hint,
-              "items": [
-                {
-                  "id": form.decision.auto_id,
-                  "value": form.decision.field.choices[0][0],
-                  "text": form.decision[0].choice_label,
-                  "checked": form.decision.value() == form.decision.field.choices[0][0]
-                },
-                {
-                  "value": form.decision.field.choices[1][0],
-                  "text": form.decision[1].choice_label,
-                  "checked": form.decision.value() == form.decision.field.choices[1][0]
-                }
-              ]
-            }) }}
+              hint=decision_hint
+            ) }}
           {% endif %}
 
           {{ button({


### PR DESCRIPTION
[Jira](https://nhsd-jira.digital.nhs.uk/browse/DTOSS-8649)

The goal of this PR is to make it easier to convert between django [BoundFields](https://docs.djangoproject.com/en/5.2/ref/forms/api/#django.forms.BoundField) and NHS.UK design system component calls.

Normally in Django, the rendering to HTML of form fields is handled by a combination of
- the field's [Widget](https://docs.djangoproject.com/en/5.2/ref/forms/widgets/#widget), and its associated template
- templates built into django itself, e.g. https://github.com/django/django/blob/main/django/forms/templates/django/forms/field.html

I explored the possibility of customising these various templates so that we could call `{{ form }}` or `{{ form.field }}` in our templates, and have it render the right components automatically. However, ultimately I decided this was too complicated, because Django's widgets are quite limited (they do not normally have access to the errors for example), and the components contain extra functionality that is not representable in Django forms, such as the conditional param in checkboxes/radios.

That said, there is still a lot of boilerplate code in our templates, so I think extracting some macros is still useful, even if we can't use them for everything.