### PR TITLE
Use snake case consistently in templates

### DIFF
--- a/manage_breast_screening/templates/_components/secondary-navigation/macro.jinja
+++ b/manage_breast_screening/templates/_components/secondary-navigation/macro.jinja
@@ -1,3 +1,3 @@
-{% macro appSecondaryNavigation(params) %}
+{% macro app_secondary_navigation(params) %}
   {%- include "_components/secondary-navigation/template.jinja" -%}
 {% endmacro %}

--- a/manage_breast_screening/templates/clinics/index.html
+++ b/manage_breast_screening/templates/clinics/index.html
@@ -2,7 +2,7 @@
 
 {% from 'tag/macro.jinja' import tag %}
 {% from '_components/count/macro.jinja' import appCount %}
-{% from '_components/secondary-navigation/macro.jinja' import appSecondaryNavigation %}
+{% from '_components/secondary-navigation/macro.jinja' import app_secondary_navigation %}
 
 {% block content %}
 <h1>{{ presenter.heading }}</h1>
@@ -24,7 +24,7 @@
 }] %}
 {% endfor %}
 
-{{ appSecondaryNavigation({
+{{ app_secondary_navigation({
   "visuallyHiddenTitle": "Secondary menu",
   "items": ns.secondaryNavItems
 }) }}

--- a/manage_breast_screening/templates/layout-app.html
+++ b/manage_breast_screening/templates/layout-app.html
@@ -39,11 +39,11 @@
 
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">
-      {% block pageNavigation %}
-      {% endblock pageNavigation %}
+      {% block page_navigation %}
+      {% endblock page_navigation %}
     </div>
   </div>
 
-  {% block pageContent %}
-  {% endblock pageContent %}
+  {% block page_content %}
+  {% endblock page_content %}
 {% endblock content %}

--- a/manage_breast_screening/templates/record_a_mammogram/ask_for_medical_information.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/ask_for_medical_information.jinja
@@ -1,6 +1,6 @@
 {% extends "wizard_step.jinja" %}
 
-{% block stepContent %}
+{% block step_content %}
   <p>Ask them about any:</p>
   <ul class="nhsuk-list nhsuk-list--bullet">
     <li>history of breast cancer</li>

--- a/manage_breast_screening/templates/record_a_mammogram/record_medical_information.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/record_medical_information.jinja
@@ -2,16 +2,17 @@
 {% from "card/macro.jinja" import card %}
 {% from "inset-text/macro.jinja" import insetText %}
 {% from "summary-list/macro.jinja" import summaryList %}
-{% block stepContent %}
+
+{% block step_content %}
 
 {% set symptoms_card_html %}
     {% set has_symptoms = false %}
 
-    {% set insetHtml %}
+    {% set inset_html %}
     <p>No symptoms have been recorded for this participant.</p>
     {% endset %}
     {{ insetText({
-      "html": insetHtml,
+      "html": inset_html,
       "classes": "nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-4"
     }) }}
 

--- a/manage_breast_screening/templates/record_a_mammogram/start_screening.jinja
+++ b/manage_breast_screening/templates/record_a_mammogram/start_screening.jinja
@@ -4,7 +4,7 @@
 {% from '_components/appointment-status/macro.jinja' import appointment_status %}
 {% from '_components/appointment-header/macro.jinja' import appointment_header %}
 {% from '_components/participant-details/macro.jinja' import participant_details %}
-{% from '_components/secondary-navigation/macro.jinja' import appSecondaryNavigation %}
+{% from '_components/secondary-navigation/macro.jinja' import app_secondary_navigation %}
 
 {% block heading %}
   <div class="app-header-with-status">
@@ -23,11 +23,11 @@
     </div>
 {% endblock %}
 
-{% block stepContent %}
+{% block step_content %}
   {{ appointment_header(appointment) }}
 
   {% if secondary_nav_items %}
-    {{ appSecondaryNavigation({
+    {{ app_secondary_navigation({
       "visuallyHiddenTitle": "Secondary menu",
       "items": secondary_nav_items
     }) }}

--- a/manage_breast_screening/templates/wizard_step.jinja
+++ b/manage_breast_screening/templates/wizard_step.jinja
@@ -5,13 +5,13 @@
 {% from 'back-link/macro.jinja' import backLink %}
 {% from 'error-summary/macro.jinja' import errorSummary %}
 
-{% block beforeContent %}
+{% block before_content %}
 {# Using javascript temporarily - this should be replaced with proper URLs #}
 {{ backLink({
   "href": "javascript:history.back()",
   "text": "Go back"
 }) }}
-{% endblock beforeContent %}
+{% endblock before_content %}
 
 {% block messages %}
     {% if form.errors %}
@@ -31,7 +31,7 @@
     {% endif %}
 {% endblock %}
 
-{% block pageContent %}
+{% block page_content %}
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-full">
 
@@ -44,7 +44,7 @@
   </h1>
   {% endblock heading %}
 
-  {% block stepContent %}{% endblock %}
+  {% block step_content %}{% endblock %}
 
   {% if form %}
   <form action="{{request.path}}" method="POST">
@@ -54,7 +54,7 @@
 
           {% if form.decision %}
             {% if form.decision.errors %}
-              {% set errorMessage = {"text": form.decision.errors | first} %}
+              {% set error_message = {"text": form.decision.errors | first} %}
             {% endif %}
 
             {{ radios({
@@ -67,7 +67,7 @@
                   "isPageHeading": false
                 }
               },
-              "errorMessage": errorMessage,
+              "errorMessage": error_message,
               "hint": {
                 "html": decision_hint|e
               } if decision_hint,
@@ -103,4 +103,4 @@
   </div>
 
 </div>
-{% endblock pageContent %}
+{% endblock page_content %}


### PR DESCRIPTION
We've opted to follow the convention of using snake_case in our jinja templates for any macros and blocks we write ourselves. Python logic appearing in templates should also be in snake_case. This should, in practice, mean that the only camelCase in our templates comes from external libraries.

Update our templates to follow these conventions.

## Review notes
Taking a quick look through the rendered screens in local dev and making sure they load correctly and look right would be a useful test of this. 