### PR TITLE
Red links

### DIFF
--- a/manage_breast_screening/assets/sass/main.scss
+++ b/manage_breast_screening/assets/sass/main.scss
@@ -26,3 +26,10 @@ h3 {
 [hidden] {
   display: none;
 }
+
+/*
+Highlight in red links that don't get anywhere yet
+*/
+a[href="#"] {
+  color: #c80000;
+}

--- a/manage_breast_screening/jinja2/layout-app.html
+++ b/manage_breast_screening/jinja2/layout-app.html
@@ -15,7 +15,7 @@
     },
     "primaryLinks": [
       {
-        "url": "#",
+        "url": "/",
         "label": "Home",
         "current": true if navActive == "home"
       },


### PR DESCRIPTION
We agreed we were going to highlight links in red if they don't go anywhere while we are building out the service. This needs to be a slightly dark red so as not to trigger axe.

![Screenshot 2025-06-03 at 15 56 32](https://github.com/user-attachments/assets/8c85bfb5-603c-4c42-a453-56cf643f527f)
